### PR TITLE
Adds params exclusion.

### DIFF
--- a/lib/onfleet-ruby/onfleet_object.rb
+++ b/lib/onfleet-ruby/onfleet_object.rb
@@ -23,7 +23,7 @@ module Onfleet
       attrs = Hash.new
       instance_variables.each do |var|
         str = var.to_s.gsub /^@/, ''
-        if respond_to? "#{str}="
+        if (respond_to?("#{str}=")) && (str != 'params')
           instance_var = instance_variable_get(var)
           if klass = Util.object_classes[str]
             if instance_var.is_a?(OnfleetObject)

--- a/onfleet-ruby.gemspec
+++ b/onfleet-ruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'onfleet-ruby'
-  s.version     = '0.1.4'
+  s.version     = '0.1.5'
   s.date        = '2016-04-08'
   s.summary     = "Onfleet ruby api"
   s.description = "To interact with Onfleet's API"


### PR DESCRIPTION
Removes `@params` from the attributes hash, preventing it from ending up in the JSON serialization of the Onfleet object when it's saved/POSTed to Onfleet's API.
